### PR TITLE
feat: Add Content Analysis Node

### DIFF
--- a/config/pipeline_config.py
+++ b/config/pipeline_config.py
@@ -268,6 +268,12 @@ class PipelineConfig:
     def log_level(self) -> str:
         """Get logging level."""
         return self.get("log_level", default="INFO")
+
+    @log_level.setter
+    def log_level(self, value: str):
+        """Set logging level."""
+        self.set("log_level", value=value)
+    
     
     @property
     def log_file(self) -> Optional[str]:

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from typing import Dict, Any, List
 
 from pocketflow import Flow
 from nodes.capture_ingestion import CaptureIngestionNode
+from nodes.content_analysis import ContentAnalysisNode
 from config.pipeline_config import PipelineConfig
 
 
@@ -34,6 +35,7 @@ class NoteGenerationPipeline:
         self.logger = logging.getLogger(__name__)
 
         self.capture_ingestion_node = CaptureIngestionNode()
+        self.content_analysis_node = ContentAnalysisNode()
         
         self.flow = Flow(self.capture_ingestion_node)
 
@@ -86,9 +88,11 @@ class NoteGenerationPipeline:
             # Add completion metadata
             shared_state["pipeline_metadata"]["end_time"] = datetime.now(timezone.utc).isoformat()
             shared_state["pipeline_metadata"]["status"] = "completed"
+            shared_state["pipeline_metadata"]["nodes_executed"] = ["capture_ingestion", "content_analysis"]
             shared_state["pipeline_stage"] = "completed"
             
             self.logger.info(f"Pipeline execution completed successfully - Session ID: {session_id}")
+            self.logger.info(f"Concepts extracted: {len(shared_state.get('extracted_concepts', {}).get('key_concepts', []))}")
             return shared_state
             
         except Exception as e:
@@ -131,6 +135,9 @@ class NoteGenerationPipeline:
             # Get the specific node
             if node_name == "capture_ingestion":
                 node = self.capture_ingestion_node
+            elif node_name == "content_analysis":
+                self.capture_ingestion_node.run(shared_state)
+                node = self.content_analysis_node
             else:
                 raise ValueError(f"Node '{node_name}' not found in pipeline")
             
@@ -251,6 +258,19 @@ def main():
                     
                     if len(captures) > 3:
                         print(f"  ... and {len(captures) - 3} more")
+                    
+                if "extracted_concepts" in result:
+                concepts = result["extracted_concepts"]
+                print(f"\nCONTENT ANALYSIS RESULTS:")
+                print(f"Key Concepts: {concepts.get('key_concepts', [])}")
+                print(f"Topics: {concepts.get('topics', [])}")
+                print(f"Entities: {list(concepts.get('entities', {}).keys())}")
+                print(f"Complexity: {concepts.get('complexity_assessment', {}).get('overall_level', 'unknown')}")
+                
+                semantic = concepts.get('semantic_analysis', {})
+                if semantic:
+                    print(f"Learning Intent: {semantic.get('primary_intent', 'unknown')}")
+                    print(f"Knowledge Domains: {semantic.get('knowledge_domains', [])}")
             
             print("="*50)
     

--- a/main.py
+++ b/main.py
@@ -260,17 +260,17 @@ def main():
                         print(f"  ... and {len(captures) - 3} more")
                     
                 if "extracted_concepts" in result:
-                concepts = result["extracted_concepts"]
-                print(f"\nCONTENT ANALYSIS RESULTS:")
-                print(f"Key Concepts: {concepts.get('key_concepts', [])}")
-                print(f"Topics: {concepts.get('topics', [])}")
-                print(f"Entities: {list(concepts.get('entities', {}).keys())}")
-                print(f"Complexity: {concepts.get('complexity_assessment', {}).get('overall_level', 'unknown')}")
-                
-                semantic = concepts.get('semantic_analysis', {})
-                if semantic:
-                    print(f"Learning Intent: {semantic.get('primary_intent', 'unknown')}")
-                    print(f"Knowledge Domains: {semantic.get('knowledge_domains', [])}")
+                    concepts = result["extracted_concepts"]
+                    print(f"\nCONTENT ANALYSIS RESULTS:")
+                    print(f"Key Concepts: {concepts.get('key_concepts', [])}")
+                    print(f"Topics: {concepts.get('topics', [])}")
+                    print(f"Entities: {list(concepts.get('entities', {}).keys())}")
+                    print(f"Complexity: {concepts.get('complexity_assessment', {}).get('overall_level', 'unknown')}")
+                    
+                    semantic = concepts.get('semantic_analysis', {})
+                    if semantic:
+                        print(f"Learning Intent: {semantic.get('primary_intent', 'unknown')}")
+                        print(f"Knowledge Domains: {semantic.get('knowledge_domains', [])}")
             
             print("="*50)
     

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -3,5 +3,6 @@ Nodes package for the AI Note Generation Pipeline
 """
 
 from .capture_ingestion import CaptureIngestionNode
+from .content_analysis import ContentAnalysisNode
 
-__all__ = ['CaptureIngestionNode']
+__all__ = ['CaptureIngestionNode', 'ContentAnalysisNode']

--- a/nodes/content_analysis.py
+++ b/nodes/content_analysis.py
@@ -265,7 +265,6 @@ Focus on educational/learning value. Return only valid JSON."""
     def _combine_analysis_results(self, individual_analyses: List[Dict[str, Any]], synthesis: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
         """Combine individual and synthesis results into final structure."""
         
-        # Aggregate all learning concepts
         all_learning_concepts = []
         all_key_terms = {}
         all_entities = {}
@@ -281,7 +280,7 @@ Focus on educational/learning value. Return only valid JSON."""
             all_skills.extend(analysis.get('skills', []))
             all_actionable_items.extend(analysis.get('actionable_items', []))
         
-        # Remove duplicates while preserving order
+        # remove duplicates while preserving order
         unique_concepts = list(dict.fromkeys(all_learning_concepts))
         unique_methodologies = list(dict.fromkeys(all_methodologies))
         unique_skills = list(dict.fromkeys(all_skills))
@@ -321,7 +320,6 @@ Focus on educational/learning value. Return only valid JSON."""
             'capture_analyses': individual_analyses
         }
         
-        # Build content_analysis metadata
         content_analysis = {
             'method': 'llm_powered',
             'model_used': config.get('llm_model', 'gpt-3.5-turbo'),
@@ -338,13 +336,13 @@ Focus on educational/learning value. Return only valid JSON."""
         
         filtered_words = [word for word in words if word not in stop_words and len(word) > 3]
         
-        # Count frequency and get top concepts
+        # count frequency and get top concepts
         word_counts = Counter(filtered_words)
         
-        # Get words that appear more than once or are long/technical
+        # get words that appear more than once or are long/technical
         key_concepts = []
         for word, count in word_counts.most_common(20):
             if count > 1 or len(word) > 6 or any(word in pattern for patterns in self.entity_patterns.values() for pattern in patterns):
                 key_concepts.append(word)
         
-        return key_concepts[:10]  # Top 10 concepts
+        return key_concepts[:10]  # top 10 concepts

--- a/nodes/content_analysis.py
+++ b/nodes/content_analysis.py
@@ -9,6 +9,7 @@ import re
 from datetime import datetime, timezone
 from typing import Dict, List, Any, Optional, Set
 from collections import Counter
+import os
 
 from pocketflow import Node as BaseNode
 from .llm_client import get_llm_client

--- a/nodes/content_analysis.py
+++ b/nodes/content_analysis.py
@@ -133,8 +133,6 @@ class ContentAnalysisNode(BaseNode):
                 'content_analysis': {'method': 'failed', 'error': str(e)}
             }
 
-        
-
 
     def post(self, shared_state: Dict[str, Any], prep_result: Dict[str, Any], exec_result: Dict[str, Any]) -> str:
         """
@@ -161,9 +159,6 @@ class ContentAnalysisNode(BaseNode):
         
         self.logger.info("Content analysis results stored in shared_state")
         return "default"
-        
-
-        
 
     
     def _analyze_single_capture(self, capture: Dict[str, Any], index: int) -> Dict[str, Any]:
@@ -319,7 +314,6 @@ class ContentAnalysisNode(BaseNode):
             'skills': unique_skills,
             'actionable_items': unique_actionable,
             
-            # From synthesis
             'session_theme': synthesis.get('session_learning_theme', 'mixed_topics'),
             'knowledge_progression': synthesis.get('knowledge_progression', []),
             'learning_path': synthesis.get('learning_path', []),
@@ -336,11 +330,9 @@ class ContentAnalysisNode(BaseNode):
                 'per_capture_levels': [a.get('complexity', 'intermediate') for a in individual_analyses]
             },
             
-            # For backward compatibility with other nodes
             'topics': [synthesis.get('session_learning_theme', 'general')],
             'key_concepts': unique_concepts[:10],  # Top 10 for compatibility
             
-            # Individual capture details
             'capture_analyses': individual_analyses
         }
         

--- a/nodes/content_analysis.py
+++ b/nodes/content_analysis.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+Content Analysis Node: Extracts concepts, entities, and semantic meaning from processed captures
+"""
+
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Dict, List, Any, Optional, Set
+from collections import Counter
+
+from pocketflow import Node as BaseNode
+from .llm_client import get_llm_client
+
+
+class ContentAnalysisNode(BaseNode):
+    """
+    Node 2: Content Analysis & Concept Extraction
+    
+    Purpose: Extract key concepts, entities, topics, and semantic meaning from captures
+    
+    Input: shared_state['raw_captures'] from Capture Ingestion node. 
+    Process: LLM analysis + entity extraction + topic classification + concept hierarchy
+    Output: shared_state['extracted_concepts'] and shared_state['content_analysis']
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.logger = logging.getLogger(__name__)
+
+        self.llm_client = None
+        self.use_llm = False
+        self._initialize_llm()
+    
+
+    def _initialize_llm(self):
+        """Initialize LLM client (tries multiple providers)"""
+        try:
+            preferred_provider = os.getenv('LLM_PROVIDER')  # 'anthropic', etc.
+            
+            self.llm_client = get_llm_client(preferred_provider)
+            self.provider_name = self.llm_client.get_provider_name()
+            
+            self.logger.info(f"LLM client initialized with provider: {self.provider_name}")
+            
+        except Exception as e:
+            self.logger.error(f"Failed to initialize any LLM provider: {str(e)}")
+            self.logger.error("Please configure at least one of:")
+            self.logger.error("- ANTHROPIC_API_KEY for Anthropic Claude")
+            raise RuntimeError(f"No LLM providers available: {str(e)}")
+
+    
+    def prep(self, shared_state: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Prepare for content analysis by validating inputs and LLM availability.
+        """
+
+    
+    def exec(self, prep_result: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Core execution: Analyze captures using LLM for learning concept extraction.
+        """
+
+
+    def post(self, shared_state: Dict[str, Any], prep_result: Dict[str, Any], exec_result: Dict[str, Any]) -> str:
+        """
+        Post-processing: Store analysis results in shared_state for Node 3.
+        """

--- a/nodes/content_analysis.py
+++ b/nodes/content_analysis.py
@@ -98,9 +98,253 @@ class ContentAnalysisNode(BaseNode):
         """
         Core execution: Analyze captures using LLM for learning concept extraction.
         """
+        self.logger.info("Starting LLM-powered content analysis")
+
+        captures = prep_result.get('captures_to_analyze', [])
+        config = prep_result.get('analysis_config', {})
+
+        if 'error' in prep_result:
+            return {'error': prep_result['error'], 'extracted_concepts': {}, 'content_analysis': {}}
+        
+        if not captures:
+            return {'extracted_concepts': {}, 'content_analysis': {}}
+
+        try:
+            # Analyze each capture individually
+            individual_analyses = []
+            for i, capture in enumerate(captures):
+                self.logger.debug(f"Analyzing capture {i+1}/{len(captures)}")
+                analysis = self._analyze_single_capture(capture, i)
+                individual_analyses.append(analysis)
+            
+            # cross-capture synthesis
+            synthesis_result = self._synthesize_across_captures(individual_analyses, captures)
+    
+            combined_result = self._combine_analysis_results(individual_analyses, synthesis_result, config)
+            
+            self.logger.info(f"LLM analysis complete: extracted {len(combined_result.get('extracted_concepts', {}).get('learning_concepts', []))} learning concepts")
+            return combined_result
+            
+        except Exception as e:
+            self.logger.error(f"LLM analysis failed: {str(e)}")
+            return {
+                'error': f"LLM analysis failed: {str(e)}",
+                'extracted_concepts': {},
+                'content_analysis': {'method': 'failed', 'error': str(e)}
+            }
+
+        
 
 
     def post(self, shared_state: Dict[str, Any], prep_result: Dict[str, Any], exec_result: Dict[str, Any]) -> str:
         """
         Post-processing: Store analysis results in shared_state for Node 3.
         """
+
+    
+    def _analyze_single_capture(self, capture: Dict[str, Any], index: int) -> Dict[str, Any]:
+        """Analyze a single capture for learning concepts using LLM."""
+        
+        content = capture['content']
+        url = capture.get('url', 'Unknown URL')
+        selected_text = capture.get('metadata', {}).get('selected_text', '')
+        
+        # focused prompt for single capture analysis
+        prompt = f"""Analyze this learning content and extract key learning information:
+
+        URL: {url}
+        Selected Text: "{selected_text}"
+        Full Content: {content[:1500]}...
+
+        Extract and return JSON with:
+        1. "learning_concepts": Core concepts being taught/learned (array of strings)
+        2. "key_terms": Important terminology and definitions (object: term -> definition)
+        3. "entities": People, companies, technologies, tools mentioned (object: name -> type)
+        4. "methodologies": Approaches, frameworks, processes described (array)
+        5. "skills": Specific skills or competencies involved (array)
+        6. "complexity": learning complexity (beginner/intermediate/advanced/expert)
+        7. "prerequisites": What knowledge is assumed/required (array)
+        8. "learning_type": type of learning content (tutorial, explanation, documentation, example, theory, practical)
+        9. "actionable_items": Concrete things a learner could do/try (array)
+        10. "main_topic": The primary subject area being learned
+
+Focus on educational/learning value. Return only valid JSON."""
+
+        try:
+            # Use provider-agnostic client
+            messages = [
+                {"role": "system", "content": "You are an expert at analyzing educational content and extracting learning concepts. Always return valid JSON focused on learning value."},
+                {"role": "user", "content": prompt}
+            ]
+            
+            # Set provider-specific defaults
+            request_params = self.llm_client.set_provider_specific_defaults(
+                temperature=0.2,
+                max_tokens=800
+            )
+            
+            response_text = self.llm_client.chat_completion(messages, **request_params)
+            result = json.loads(response_text)
+            result['capture_index'] = index
+            result['capture_id'] = capture.get('id', f'capture_{index}')
+            return result
+            
+        except Exception as e:
+            self.logger.warning(f"Failed to analyze capture {index}: {str(e)}")
+            return {
+                'capture_index': index,
+                'capture_id': capture.get('id', f'capture_{index}'),
+                'error': str(e),
+                'learning_concepts': [],
+                'key_terms': {},
+                'entities': {},
+                'main_topic': 'unknown'
+            }
+
+
+    def _synthesize_across_captures(self, individual_analyses: List[Dict[str, Any]], captures: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Synthesize learning insights across all captures using LLM."""
+        
+        # Prepare summary of individual analyses
+        analysis_summary = []
+        for i, analysis in enumerate(individual_analyses):
+            summary = {
+                'capture': i + 1,
+                'main_topic': analysis.get('main_topic', 'unknown'),
+                'learning_concepts': analysis.get('learning_concepts', [])[:3],  # Top 3
+                'complexity': analysis.get('complexity', 'unknown'),
+                'learning_type': analysis.get('learning_type', 'unknown')
+            }
+            analysis_summary.append(summary)
+        
+        # Create synthesis prompt
+        prompt = f"""Analyze this learning session where a user captured {len(captures)} pieces of content:
+
+        Individual Content Analysis:
+        {json.dumps(analysis_summary, indent=2)}
+
+        Synthesize across all captures and return JSON with:
+        1. "session_learning_theme": Overall theme/topic of this learning session
+        2. "knowledge_progression": How concepts build on each other (array of steps)
+        3. "learning_path": Suggested order for learning these concepts (array)
+        4. "knowledge_gaps": Important related concepts not covered (array)
+        5. "session_complexity": Overall session difficulty (beginner/intermediate/advanced/expert)
+        6. "learning_goals": What the user is trying to achieve (inferred goals)
+        7. "next_steps": Recommended follow-up learning (array)
+        8. "concept_connections": How the main concepts relate (object describing relationships)
+        9. "practical_applications": Real-world uses for this knowledge (array)
+        10. "mastery_indicators": How to know if concepts are understood (array)
+
+        Focus on the learning journey and knowledge building. Return only valid JSON."""
+
+        try:
+            messages = [
+                {"role": "system", "content": "You are an expert learning analyst who understands how knowledge builds across multiple learning resources."},
+                {"role": "user", "content": prompt}
+            ]
+            
+            # Set provider-specific defaults
+            request_params = self.llm_client.set_provider_specific_defaults(
+                temperature=0.3,
+                max_tokens=1000
+            )
+            
+            response_text = self.llm_client.chat_completion(messages, **request_params)
+            return json.loads(response_text)
+            
+        except Exception as e:
+            self.logger.warning(f"Failed to synthesize across captures: {str(e)}")
+            return {
+                'session_learning_theme': 'mixed_topics',
+                'session_complexity': 'intermediate',
+                'learning_goals': ['general_learning'],
+                'error': str(e)
+            }
+
+
+    def _combine_analysis_results(self, individual_analyses: List[Dict[str, Any]], synthesis: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
+        """Combine individual and synthesis results into final structure."""
+        
+        # Aggregate all learning concepts
+        all_learning_concepts = []
+        all_key_terms = {}
+        all_entities = {}
+        all_methodologies = []
+        all_skills = []
+        all_actionable_items = []
+        
+        for analysis in individual_analyses:
+            all_learning_concepts.extend(analysis.get('learning_concepts', []))
+            all_key_terms.update(analysis.get('key_terms', {}))
+            all_entities.update(analysis.get('entities', {}))
+            all_methodologies.extend(analysis.get('methodologies', []))
+            all_skills.extend(analysis.get('skills', []))
+            all_actionable_items.extend(analysis.get('actionable_items', []))
+        
+        # Remove duplicates while preserving order
+        unique_concepts = list(dict.fromkeys(all_learning_concepts))
+        unique_methodologies = list(dict.fromkeys(all_methodologies))
+        unique_skills = list(dict.fromkeys(all_skills))
+        unique_actionable = list(dict.fromkeys(all_actionable_items))
+        
+        # Build final extracted_concepts structure
+        extracted_concepts = {
+            'learning_concepts': unique_concepts,
+            'key_terms': all_key_terms,
+            'entities': all_entities,
+            'methodologies': unique_methodologies,
+            'skills': unique_skills,
+            'actionable_items': unique_actionable,
+            
+            # From synthesis
+            'session_theme': synthesis.get('session_learning_theme', 'mixed_topics'),
+            'knowledge_progression': synthesis.get('knowledge_progression', []),
+            'learning_path': synthesis.get('learning_path', []),
+            'knowledge_gaps': synthesis.get('knowledge_gaps', []),
+            'learning_goals': synthesis.get('learning_goals', []),
+            'next_steps': synthesis.get('next_steps', []),
+            'concept_connections': synthesis.get('concept_connections', {}),
+            'practical_applications': synthesis.get('practical_applications', []),
+            'mastery_indicators': synthesis.get('mastery_indicators', []),
+            
+            # Complexity assessment
+            'complexity_assessment': {
+                'overall_level': synthesis.get('session_complexity', 'intermediate'),
+                'per_capture_levels': [a.get('complexity', 'intermediate') for a in individual_analyses]
+            },
+            
+            # For backward compatibility with other nodes
+            'topics': [synthesis.get('session_learning_theme', 'general')],
+            'key_concepts': unique_concepts[:10],  # Top 10 for compatibility
+            
+            # Individual capture details
+            'capture_analyses': individual_analyses
+        }
+        
+        # Build content_analysis metadata
+        content_analysis = {
+            'method': 'llm_powered',
+            'model_used': config.get('llm_model', 'gpt-3.5-turbo'),
+            'confidence': 'high',
+            'captures_analyzed': len(individual_analyses),
+            'synthesis_performed': True,
+            'processing_time': datetime.now(timezone.utc).isoformat()
+        }
+        
+        return {
+            'extracted_concepts': extracted_concepts,
+            'content_analysis': content_analysis
+        } 'take', 'than', 'call', 'came', 'each', 'part', 'that', 'this', 'will', 'with', 'have', 'from', 'they', 'know', 'want', 'been', 'good', 'much', 'some', 'time', 'just', 'also', 'many', 'then', 'them', 'well', 'were'}
+        
+        filtered_words = [word for word in words if word not in stop_words and len(word) > 3]
+        
+        # Count frequency and get top concepts
+        word_counts = Counter(filtered_words)
+        
+        # Get words that appear more than once or are long/technical
+        key_concepts = []
+        for word, count in word_counts.most_common(20):
+            if count > 1 or len(word) > 6 or any(word in pattern for patterns in self.entity_patterns.values() for pattern in patterns):
+                key_concepts.append(word)
+        
+        return key_concepts[:10]  # Top 10 concepts

--- a/nodes/llm_client.py
+++ b/nodes/llm_client.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+LLM Client Wrapper: Provider-agnostic interface for different LLM services
+"""
+
+import os
+import json
+import logging
+from typing import Dict, List, Any, Optional, Union
+from abc import ABC, abstractmethod
+
+
+class LLMProvider(ABC):
+    """Abstract base class for LLM providers"""
+    
+    @abstractmethod
+    def chat_completion(self, messages: List[Dict[str, str]], **kwargs) -> str:
+        """Generate a chat completion response"""
+        pass
+    
+    @abstractmethod
+    def is_available(self) -> bool:
+        """Check if the provider is available and configured"""
+        pass
+
+
+class AnthropicProvider(LLMProvider):
+    """Anthropic Claude API provider"""
+    
+    def __init__(self):
+        self.client = None
+        self.logger = logging.getLogger(__name__)
+        self._initialize()
+    
+    def _initialize(self):
+        try:
+            import anthropic
+            api_key = os.getenv('ANTHROPIC_API_KEY')
+            if api_key:
+                self.client = anthropic.Anthropic(api_key=api_key)
+                self.logger.info("Anthropic provider initialized")
+            else:
+                self.logger.warning("ANTHROPIC_API_KEY not found")
+        except ImportError:
+            self.logger.warning("Anthropic library not installed")
+        except Exception as e:
+            self.logger.error(f"Anthropic initialization failed: {str(e)}")
+    
+    def chat_completion(self, messages: List[Dict[str, str]], **kwargs) -> str:
+        if not self.client:
+            raise RuntimeError("Anthropic client not initialized")
+        
+        model = kwargs.get('model', 'claude-3-sonnet-20240229')
+        max_tokens = kwargs.get('max_tokens', 1000)
+        
+        # Convert messages to Anthropic format
+        system_message = ""
+        user_messages = []
+        
+        for msg in messages:
+            if msg['role'] == 'system':
+                system_message = msg['content']
+            else:
+                user_messages.append(msg)
+        
+        response = self.client.messages.create(
+            model=model,
+            max_tokens=max_tokens,
+            system=system_message if system_message else "You are a helpful assistant.",
+            messages=user_messages
+        )
+        
+        return response.content[0].text
+    
+    def is_available(self) -> bool:
+        return self.client is not None
+
+
+class LLMClient:
+    """
+    Universal LLM client that automatically selects the best available provider
+    """
+    
+    def __init__(self, preferred_provider: Optional[str] = None):
+        self.logger = logging.getLogger(__name__)
+        self.provider = None
+        self.provider_name = None
+        
+        # Initialize providers (currently only added Anthropic)
+        providers = {
+            'anthropic': AnthropicProvider()
+        }
+        
+        # user specified preferred LLM provider
+        if preferred_provider and preferred_provider in providers:
+            provider = providers[preferred_provider]
+            if provider.is_available():
+                self.provider = provider
+                self.provider_name = preferred_provider
+                self.logger.info(f"Using preferred LLM provider: {preferred_provider}")
+                return
+        
+        # Otherwise, order of preference
+        for name, provider in providers.items():
+            if provider.is_available():
+                self.provider = provider
+                self.provider_name = name
+                self.logger.info(f"Using LLM provider: {name}")
+                return
+        
+        self.logger.error("No LLM providers available")
+        raise RuntimeError("No LLM providers configured. Please set up at least one of: OPENAI_API_KEY, ANTHROPIC_API_KEY, or run Ollama locally")
+    
+    def chat_completion(self, messages: List[Dict[str, str]], **kwargs) -> str:
+        """Generate a chat completion using the active provider"""
+        if not self.provider:
+            raise RuntimeError("No LLM provider available")
+        
+        try:
+            return self.provider.chat_completion(messages, **kwargs)
+        except Exception as e:
+            self.logger.error(f"LLM request failed with {self.provider_name}: {str(e)}")
+            raise
+    
+    def is_available(self) -> bool:
+        """Check if any provider is available"""
+        return self.provider is not None
+    
+    def get_provider_name(self) -> str:
+        """Get the name of the active provider"""
+        return self.provider_name or "none"
+    
+    def get_model_recommendations(self) -> Dict[str, str]:
+        """Get recommended models for each provider"""
+        recommendations = {
+            'anthropic': 'claude-3-sonnet-20240229', 
+        }
+        return recommendations
+    
+    def set_provider_specific_defaults(self, **kwargs) -> Dict[str, Any]:
+        """Set provider-specific defaults for requests"""
+        defaults = kwargs.copy()
+
+        if self.provider_name == 'anthropic':
+            defaults.setdefault('model', 'claude-3-sonnet-20240229')
+            defaults.setdefault('temperature', 0.3)
+        
+        return defaults
+
+def get_llm_client(preferred_provider: Optional[str] = None) -> LLMClient:
+    """
+    Factory function to get an LLM client
+    
+    Args:
+        preferred_provider: Preferred provider ('anthropic')
+    
+    Returns:
+        Configured LLM client
+    """
+    # Allow configuration via environment variable
+    if not preferred_provider:
+        preferred_provider = os.getenv('LLM_PROVIDER')
+    
+    return LLMClient(preferred_provider)

--- a/nodes/llm_client.py
+++ b/nodes/llm_client.py
@@ -133,7 +133,7 @@ class LLMClient:
     def get_model_recommendations(self) -> Dict[str, str]:
         """Get recommended models for each provider"""
         recommendations = {
-            'anthropic': 'claude-3-sonnet-20240229', 
+            'anthropic': 'claude-3-5-haiku-latest', 
         }
         return recommendations
     
@@ -142,7 +142,7 @@ class LLMClient:
         defaults = kwargs.copy()
 
         if self.provider_name == 'anthropic':
-            defaults.setdefault('model', 'claude-3-sonnet-20240229')
+            defaults.setdefault('model', 'claude-3-5-haiku-latest')
             defaults.setdefault('temperature', 0.3)
         
         return defaults

--- a/nodes/llm_client.py
+++ b/nodes/llm_client.py
@@ -50,7 +50,7 @@ class AnthropicProvider(LLMProvider):
         if not self.client:
             raise RuntimeError("Anthropic client not initialized")
         
-        model = kwargs.get('model', 'claude-3-sonnet-20240229')
+        model = kwargs.get('model', 'claude-3-5-haiku-latest')
         max_tokens = kwargs.get('max_tokens', 1000)
         
         # Convert messages to Anthropic format

--- a/pipeline_orchestrator.py
+++ b/pipeline_orchestrator.py
@@ -198,7 +198,7 @@ class PipelineOrchestrator:
             'content_types_detected': capture_summary.get('content_types_detected', {}),
             'domains_processed': capture_summary.get('domains_processed', []),
             'average_content_length': capture_summary.get('average_content_length', 0),
-            'captures_processed': pipeline_metadata.get('captures_processed', 0)
+            'captures_processed': pipeline_metadata.get('captures_processed', 0),
 
             # Content analysis stats
             'concepts_extracted': content_summary.get('concepts_extracted', 0),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,41 @@
+# Pocketflow Notes Pipeline - Requirements
+# Core dependencies for the complete pipeline with LLM support
+
+# ==========================================
+# Core Pipeline Framework
+# ==========================================
 pocketflow-framework
+
+# ==========================================
+# Content Processing & Web Scraping
+# ==========================================
 beautifulsoup4>=4.12.0
 html2text>=2020.1.16
 python-dateutil>=2.8.2
 validators>=0.20.0
 urllib3>=1.26.0
 requests>=2.28.0
+
+# ==========================================
+# Web API Server
+# ==========================================
 flask==3.0.0
 flask-cors==4.0.0
+
+# ==========================================
+# LLM Providers (Choose what you need)
+# ==========================================
+
+# Anthropic Claude
+anthropic>=0.8.0
+
+# ==========================================
+# Development & Testing
+# ==========================================
+# pytest>=7.0.0
+# pytest-flask>=1.2.0
+
+# ==========================================
+# Environment Management
+# ==========================================
+python-dotenv>=1.0.0


### PR DESCRIPTION
feat: add content analysis node (second node) to pocketflow pipeline 

- Added ContentAnalysisNode extracts learning concepts, key terms, entities, methodologies, and session-level synthesis across captures
- Fixed PocketFlow integration 
- Pipeline Orchestrator Improved data conversion between API and pipeline formats, comprehensive result formatting with processing statistics and insights generation
- added missing log level property setter in pipeline config 
- integrated LLM client wrapper to make it LLM provider agnostic. Have added anthropic only for now
- used anthropic claude-3-5-haiku-latest for testing, set anthropic default

Complete data flow working - Chrome Extension → Flask API → Pipeline Orchestrator → PocketFlow (Capture Ingestion + Content Analysis) → Results Storage with comprehensive logging and error recovery

Tested successfully: 4 notes crypto learning session test extracted 10 learning concepts with full session theme analysis and knowledge progression mapping.